### PR TITLE
Feature: Add Terraform Infrastructure for AWS Deployment

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,27 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore lock files
+.terraform.lock.hcl
+
+# Ignore override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/terraform/main/main.tf
+++ b/terraform/main/main.tf
@@ -1,0 +1,31 @@
+module "vpc" {
+  source = "../modules/vpc"
+
+  environment         = var.environment
+  vpc_cidr           = var.vpc_cidr
+  public_subnets_cidr = var.public_subnets_cidr
+  availability_zones  = var.availability_zones
+}
+
+module "security" {
+  source = "../modules/security"
+
+  environment = var.environment
+  vpc_id     = module.vpc.vpc_id
+}
+
+module "ec2" {
+  source = "../modules/ec2"
+
+  environment       = var.environment
+  subnet_id        = module.vpc.public_subnet_ids[0]
+  security_group_id = module.security.security_group_id
+  key_name         = var.key_name
+  instance_type    = var.instance_type
+  app_name         = var.app_name
+  app_port         = var.app_port
+}
+
+output "application_url" {
+  value = "http://${module.ec2.instance_public_ip}"
+}

--- a/terraform/main/provider.tf
+++ b/terraform/main/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.2.0"
+}
+
+provider "aws" {
+  region = "ap-southeast-1"
+}

--- a/terraform/main/variables.tf
+++ b/terraform/main/variables.tf
@@ -1,0 +1,46 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "production"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets_cidr" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "availability_zones" {
+  description = "Availability zones in ap-southeast-1"
+  type        = list(string)
+  default     = ["ap-southeast-1a", "ap-southeast-1b"]
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "key_name" {
+  description = "SSH key pair name"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "mcp-demo"
+}
+
+variable "app_port" {
+  description = "Application port"
+  type        = number
+  default     = 80
+}

--- a/terraform/modules/ec2/main.tf
+++ b/terraform/modules/ec2/main.tf
@@ -1,0 +1,51 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical Ubuntu AWS account ID
+}
+
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [var.security_group_id]
+  associate_public_ip_address = true
+
+  key_name = var.key_name
+
+  user_data = templatefile("${path.module}/user_data.sh.tpl", {
+    app_name = var.app_name
+    app_port = var.app_port
+  })
+
+  root_block_device {
+    volume_size = 20
+    volume_type = "gp3"
+  }
+
+  tags = {
+    Name        = "${var.environment}-web"
+    Environment = var.environment
+  }
+}
+
+resource "aws_eip" "web" {
+  instance = aws_instance.web.id
+  domain   = "vpc"
+
+  tags = {
+    Name        = "${var.environment}-web-eip"
+    Environment = var.environment
+  }
+}

--- a/terraform/modules/ec2/user_data.sh.tpl
+++ b/terraform/modules/ec2/user_data.sh.tpl
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Update system
+apt-get update
+apt-get upgrade -y
+
+# Install Node.js and npm
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+apt-get install -y nodejs
+
+# Install Nginx
+apt-get install -y nginx
+
+# Install Git
+apt-get install -y git
+
+# Create app directory
+mkdir -p /var/www/${app_name}
+
+# Clone the application
+git clone https://github.com/congdinh2008/mcp-demo.git /tmp/app
+
+# Install dependencies and build
+cd /tmp/app/mcp-demo
+npm install
+npm run build
+
+# Copy built files to nginx directory
+cp -r dist/* /var/www/${app_name}/
+
+# Configure Nginx
+cat > /etc/nginx/sites-available/default << 'EOF'
+server {
+    listen ${app_port} default_server;
+    listen [::]:${app_port} default_server;
+    
+    root /var/www/${app_name};
+    index index.html;
+    
+    server_name _;
+    
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+EOF
+
+# Restart Nginx
+systemctl restart nginx

--- a/terraform/modules/ec2/variables.tf
+++ b/terraform/modules/ec2/variables.tf
@@ -1,0 +1,45 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "subnet_id" {
+  description = "Subnet ID where the instance will be launched"
+  type        = string
+}
+
+variable "security_group_id" {
+  description = "Security group ID for the instance"
+  type        = string
+}
+
+variable "key_name" {
+  description = "SSH key pair name"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "mcp-demo"
+}
+
+variable "app_port" {
+  description = "Application port"
+  type        = number
+  default     = 80
+}
+
+output "instance_public_ip" {
+  value = aws_eip.web.public_ip
+}
+
+output "instance_id" {
+  value = aws_instance.web.id
+}

--- a/terraform/modules/security/main.tf
+++ b/terraform/modules/security/main.tf
@@ -1,0 +1,42 @@
+resource "aws_security_group" "web" {
+  name        = "${var.environment}-web-sg"
+  description = "Security group for web application"
+  vpc_id      = var.vpc_id
+
+  # HTTP access
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # HTTPS access
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # SSH access
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Outbound traffic
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "${var.environment}-web-sg"
+    Environment = var.environment
+  }
+}

--- a/terraform/modules/security/variables.tf
+++ b/terraform/modules/security/variables.tf
@@ -1,0 +1,13 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+output "security_group_id" {
+  value = aws_security_group.web.id
+}

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,0 +1,52 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name        = "${var.environment}-vpc"
+    Environment = var.environment
+  }
+}
+
+resource "aws_subnet" "public" {
+  count                   = length(var.public_subnets_cidr)
+  vpc_id                 = aws_vpc.main.id
+  cidr_block             = element(var.public_subnets_cidr, count.index)
+  availability_zone      = element(var.availability_zones, count.index)
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name        = "${var.environment}-public-subnet-${count.index + 1}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name        = "${var.environment}-igw"
+    Environment = var.environment
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name        = "${var.environment}-public-route"
+    Environment = var.environment
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.public_subnets_cidr)
+  subnet_id      = element(aws_subnet.public.*.id, count.index)
+  route_table_id = aws_route_table.public.id
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,0 +1,27 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+}
+
+variable "public_subnets_cidr" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+}
+
+variable "availability_zones" {
+  description = "Availability zones"
+  type        = list(string)
+}
+
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}


### PR DESCRIPTION
This PR adds Terraform infrastructure code for deploying the React application to AWS EC2 in the ap-southeast-1 region.

### Infrastructure Components Added:

#### VPC Module
- Creates a VPC with public subnets across two availability zones
- Sets up Internet Gateway and routing tables
- Configures proper networking for public access

#### Security Module
- Creates security groups for the EC2 instance
- Configures inbound rules for:
  - HTTP (80)
  - HTTPS (443)
  - SSH (22)
- Sets up outbound internet access

#### EC2 Module
- Provisions t2.micro instance with Ubuntu 22.04 LTS
- Implements user data script for application deployment
- Sets up Elastic IP for stable addressing
- Configures root volume with 20GB gp3 storage

#### Configuration Management
- Added .gitignore for Terraform-specific files
- Organized code in modules for better maintainability
- Implemented variables for environment configuration

### Manual Testing Completed
- Successfully tested resource creation
- Verified clean resource destruction
- Confirmed application deployment process

### Next Steps
1. Set up CI/CD pipeline for automated deployments
2. Implement staging environment
3. Add monitoring and alerting
4. Configure SSL/TLS certificates

All terraform configurations have been tested locally and resources can be created/destroyed successfully.